### PR TITLE
Added Feature: Correct Mode to FLRig

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -1,5 +1,7 @@
 let options = {
-    'flrig-uri': 'http://127.0.0.1:12345/'
+    'flrig-uri': 'http://127.0.0.1:12345/',
+    'digi-mode': 'DATA-U',
+    'cw-mode': 'CW-L'
 }
 
 loadOptions();
@@ -16,10 +18,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         switch (request.message) {
             case 'setVfo':
                 setVfo(request.qrg);
-                if ((request.qrg) < 7999000) {
-                    setMode('LSB');
+
+                if ((request.mode) == 'CW') {
+                    setMode(options['cw-mode'])
+                } else if ((request.mode) == 'DIGITAL') {
+                    setMode(options['digi-mode'])
                 } else {
-                    setMode('USB');
+                    setMode(request.mode)
                 }
                 break;
             case 'loadOptions':

--- a/bg.js
+++ b/bg.js
@@ -17,8 +17,6 @@ function loadOptions() {
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         switch (request.message) {
             case 'setVfo':
-                setVfo(request.qrg);
-
                 if ((request.mode) == 'CW') {
                     setMode(options['cw-mode'])
                 } else if ((request.mode) == 'DIGITAL') {
@@ -26,6 +24,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                 } else {
                     setMode(request.mode)
                 }
+                
+                setVfo(request.qrg);
                 break;
             case 'loadOptions':
                 loadOptions()

--- a/content_script.js
+++ b/content_script.js
@@ -4,6 +4,12 @@ document.addEventListener('click', function (event) {
 
     event.preventDefault();
     let qrg = event.target.innerText.replace(/[\s|,]/g, '') * 100;
-    chrome.runtime.sendMessage({"message": "setVfo", "qrg": qrg});
+    let row = event.target.closest('tr');
+    let mode = row.querySelector('.mode.hidden').innerText;
+    let band = row.querySelector('.band.hidden').innerText;
+
+    // Now you have both the frequency (qrg) and the mode values
+    console.log("Frequency: ", qrg, " (", band, "m), Mode: ", mode);
+    chrome.runtime.sendMessage({"message": "setVfo", "qrg": qrg, "mode": mode, "band": band});
 
 }, false);

--- a/options.html
+++ b/options.html
@@ -16,6 +16,16 @@
         <input type="text" class="form-control option" id="flrig-uri" aria-describedby="flrig-uri-help">
         <div id="flrig-uri-help" class="form-text">e.g. 'http://localhost:12345/'</div>
     </div>
+    <div class="mb-3">
+        <label for="cw-mode" class="form-label">FLRig CW Mode</label>
+        <input type="text" class="form-control option" id="cw-mode" aria-describedby="cw-mode-help">
+        <div id="cw-mode-help" class="form-text">e.g. 'CW-L'</div>
+    </div>
+    <div class="mb-3">
+        <label for="digi-mode" class="form-label">FLRig Data Mode</label>
+        <input type="text" class="form-control option" id="digi-mode" aria-describedby="digi-mode-help">
+        <div id="digi-mode-help" class="form-text">e.g. 'DATA-U'</div>
+    </div>
 
     <button type="button" id="save-btn" class="btn btn-primary">Save</button>
 </div>

--- a/options.js
+++ b/options.js
@@ -26,7 +26,9 @@ function saveOptions() {
 
 function restoreOptions() {
     let defaultOptions = {
-        'flrig-uri': 'http://127.0.0.1:12345/'
+        'flrig-uri': 'http://127.0.0.1:12345/',
+        'digi-mode': 'DATA-U',
+        'cw-mode': 'CW-L'
     }
 
     chrome.storage.sync.get({


### PR DESCRIPTION
Hi!
I've stumbled upon your nice small extension!

Using it, i've noticed that it always sets the mode to USB/LSB. I've now added, that it checks the hidden mode enty of DXHeat and uses this one. 
The options menu also features now two more entries: CW-Mode and Digi-Mode. These entries specifiy the Rig-Mode, for cw and digital respectively. 

Hope somebody else will find this helpful! 